### PR TITLE
Added error checking to the scanner

### DIFF
--- a/include/scanner.h
+++ b/include/scanner.h
@@ -12,7 +12,7 @@ class Scanner final
     private:
         std::vector<Dfa*> dfas;
     public:
-        std::vector<Token*> *Scan(std::ifstream& file);
+        int Scan(std::ifstream& file, std::vector<Token*> *tokens);
         Scanner();
 };
 

--- a/include/scanner.h
+++ b/include/scanner.h
@@ -11,7 +11,7 @@ class Scanner final
     private:
         std::vector<Dfa*> dfas;
     public:
-        std::vector<Token*> *Scan(std::ifstream& file);
+        int Scan(std::ifstream& file, std::vector<Token*> *tokens);
         Scanner();
 
         ~Scanner()

--- a/include/token.h
+++ b/include/token.h
@@ -13,6 +13,7 @@ enum TOKEN_TYPE {
     TT_INVALID,
     TT_ID,
     TT_COMMENT,
+    TT_WHITESPACE,
 
     // Char literal token type
     TT_CHARACTER,

--- a/include/whitespaceAndControlDfa.h
+++ b/include/whitespaceAndControlDfa.h
@@ -1,0 +1,17 @@
+#ifndef __WHITESPACE_H__
+#define __WHITESPACE_H__
+
+#include "dfa.h"
+#include <string>
+
+class WhitespaceAndControlDfa final : public Dfa {
+    private:
+        void initDfa();
+        TOKEN_TYPE getTokenType();
+    public:
+        WhitespaceAndControlDfa();
+        
+        static TOKEN_TYPE endTokenType;
+};
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,16 +3,37 @@
 #include <vector>
 #include "scanner.h"
 
+void cleanUp(std::vector<std::vector<Token*> *> tokens)
+{
+    for (unsigned int i = 0; i < tokens.size(); i++) {
+        for(unsigned int j = 0; j < tokens[i]->size(); j++) {
+            delete [] tokens[i]->at(j);
+        }
+        delete [] tokens[i];
+    }
+}
+
 int main(int argc, char *argv[])
 {
     std::ifstream file;
     std::vector<std::vector<Token*> *> tokens;
+    std::vector<Token*> *tokenList;
     Scanner scanner;
+    
+    int result;
 
     for (int i = 1; i <= argc; i++) {
         file.open(argv[i], std::ifstream::in);
-        tokens.push_back(scanner.Scan(file));
+        tokenList = new std::vector<Token*>();
+        result = scanner.Scan(file, tokenList);
+        tokens.push_back(tokenList);
         file.close();
+        
+        //Error out
+        if(result != 0){
+            cleanUp(tokens);
+            return 42;
+        }
     }
 
     std::cout << "Print out tokens to prove it worked :D\n\n";
@@ -21,4 +42,7 @@ int main(int argc, char *argv[])
             std::cout << tokens[i]->at(j)->getString() << "\n";
         }
     }
+    
+    cleanUp(tokens);
+    return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,16 @@
 #include "scanner.h"
 #include "weeder.h"
 
+void cleanUp(std::vector<std::vector<Token*> *> tokens)
+{
+    for (unsigned int i = 0; i < tokens.size(); i++) {
+        for(unsigned int j = 0; j < tokens[i]->size(); j++) {
+            delete [] tokens[i]->at(j);
+        }
+        delete [] tokens[i];
+    }
+}
+
 int main(int argc, char *argv[])
 {
     std::ifstream file;
@@ -11,11 +21,23 @@ int main(int argc, char *argv[])
 
     Scanner scanner;
     Weeder weeder = Weeder();
+    std::vector<Token*> *tokenList;
+    std::map<std::string, std::string> symbol_table;
+    
+    int result;
 
     for (int i = 1; i <= argc; i++) {
         file.open(argv[i], std::ifstream::in);
-        tokens.push_back(scanner.Scan(file));
+        tokenList = new std::vector<Token*>();
+        result = scanner.Scan(file, tokenList);
+        tokens.push_back(tokenList);
         file.close();
+        
+        //Error out
+        if(result != 0){
+            cleanUp(tokens);
+            return 42;
+        }
     }
 
     // TODO: Remove Later (:
@@ -31,4 +53,7 @@ int main(int argc, char *argv[])
     //       to do this yet.
     ParseTree* tree = buildParseTree(tokens);
     weeder.weedParseTree(tree);
+    
+    cleanUp(tokens);
+    return 0;
 }

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -7,6 +7,7 @@
 #include "keywordDfa.h"
 #include "singleCommentDfa.h"
 #include "multiCommentDfa.h"
+#include "whitespaceAndControlDfa.h"
 
 #include <iostream>
 #include <cassert>
@@ -16,7 +17,7 @@ Scanner::Scanner()
 {
     // Dfas must be ordered in reverse priority.
     // Dfas that are later in the list will have priority over earlier Dfas
-    std::vector<Dfa*> dfas;
+    dfas.push_back(new WhitespaceAndControlDfa());
     dfas.push_back(new SingleCommentDfa());
     dfas.push_back(new MultiCommentDfa());
     dfas.push_back(new IdentifierDfa());
@@ -27,9 +28,8 @@ Scanner::Scanner()
     dfas.push_back(new KeywordDfa());
 }
 
-std::vector<Token*> *Scanner::Scan(std::ifstream& file)
+int Scanner::Scan(std::ifstream& file, std::vector<Token*> *tokens)
 {
-    std::vector<Token*> *tokens =  new std::vector<Token*>();
     int c = -2;
     
     int numDfas = this->dfas.size();
@@ -57,6 +57,7 @@ std::vector<Token*> *Scanner::Scan(std::ifstream& file)
                 std::cerr << "Invalid character with code: " 
                           << c 
                           << "\n Input files must contain only ASCII characters";
+                return -1;
             }
 
             // Line feed character LF
@@ -89,7 +90,13 @@ std::vector<Token*> *Scanner::Scan(std::ifstream& file)
         assert(errorCount <= numDfas); 
 
         if (errorCount == numDfas) {
-            if(type != TT_INVALID && type != TT_COMMENT) {
+        
+            if(type == TT_INVALID){
+                std::cerr << "Invalid token with lexime: " << lexime << (char)c << "\n";
+                return -2;
+            }
+        
+            if(type != TT_COMMENT && type != TT_WHITESPACE) {
                 tokens->push_back(new Token(type, lexime, std::pair <unsigned int, unsigned int>(tokenLine, tokenCollumn)));
             }
 
@@ -99,12 +106,6 @@ std::vector<Token*> *Scanner::Scan(std::ifstream& file)
             errorCount = 0;    
             tokenLine = currentLine;
             tokenCollumn = currentColumn;
-
-            // Eliminates whitespace and control characters.
-            // This seemed more reasonable than creating an entire dfa for the same purpose
-            if(c <= 32 || c == 127) {
-                c = -2;
-            }
 
             for(int i = 0; i < numDfas; i++) {
                 dfas[i]->resetDfa();
@@ -116,5 +117,5 @@ std::vector<Token*> *Scanner::Scan(std::ifstream& file)
         }
     }
     
-    return tokens;
+    return 0;
 }

--- a/src/whitespaceAndControlDfa.cpp
+++ b/src/whitespaceAndControlDfa.cpp
@@ -1,0 +1,37 @@
+#include "whitespaceAndControlDfa.h"
+#include "states.h"
+
+TOKEN_TYPE WhitespaceAndControlDfa::endTokenType = TT_INVALID;
+
+int checkCharacter(char c, int current_state)
+{
+    //currently matches EOF as well
+    //we can change this if we ever want to create an EOF token
+    if(c <= 32 || c == 127) {
+        WhitespaceAndControlDfa::endTokenType = TT_WHITESPACE;
+        return DS_ACCEPT;
+    }
+
+    return DS_ERROR;
+}
+
+void WhitespaceAndControlDfa::initDfa()
+{
+    dfa[DS_ERROR] = std::make_pair(DS_ERROR, &error);
+    dfa[DS_START] = std::make_pair(DS_RUNNING, &checkCharacter);
+    dfa[DS_ACCEPT] = std::make_pair(DS_ACCEPT, &checkCharacter);
+}
+
+TOKEN_TYPE WhitespaceAndControlDfa::getTokenType()
+{
+    if(dfa[current_state].first != DS_ACCEPT) {
+        return TT_INVALID;
+    }
+
+    return endTokenType;
+}
+
+WhitespaceAndControlDfa::WhitespaceAndControlDfa() : Dfa()
+{
+    initDfa();
+}


### PR DESCRIPTION
Scanner no longer returns a vector of tokens. Instead it accepts a
pointer to a vector as input and returns an int as a result code.
Scanner will now throw an error if an invalid token is generated.
Added dfa to consume input for whitespace and control characters.
Added cleanup to free memory on program termination.
Fixed a bug that was causing the scanner to initialize with 0 dfas.
