### PR TITLE
Resolving issue #63, 64, 65 and 66 plus some hierarchyChecking changes

### DIFF
--- a/include/AST/interfaceMethod.h
+++ b/include/AST/interfaceMethod.h
@@ -49,62 +49,6 @@ class InterfaceMethod : public Ast {
             return signature + ')';
         }
 
-        //declaring an interface method to be static should cause an error
-        bool isStatic() {
-            ModifiersStar* ms = getModifiersStar();
-
-            if (!ms->isEpsilon()) {
-                Modifiers* m = ms->getListOfModifiers();
-
-                while (m != NULL) {
-                    if (m->getCurrentModifierAsString() == "static") {
-                        return true;
-                    }
-
-                    m = m->getNextModifier();
-                }
-            }
-
-            return false;
-        }
-
-        bool isProtected() {
-            ModifiersStar* ms = getModifiersStar();
-
-            if (!ms->isEpsilon()) {
-                Modifiers* m = ms->getListOfModifiers();
-
-                while (m != NULL) {
-                    if (m->getCurrentModifierAsString() == "protected") {
-                        return true;
-                    }
-
-                    m = m->getNextModifier();
-                }
-            }
-
-            return false;
-        }
-        
-        //declaring an interface method to be final should cause an error
-        bool isFinal() {
-            ModifiersStar* ms = getModifiersStar();
-
-            if (!ms->isEpsilon()) {
-                Modifiers* m = ms->getListOfModifiers();
-
-                while (m != NULL) {
-                    if (m->getCurrentModifierAsString() == "final") {
-                        return true;
-                    }
-
-                    m = m->getNextModifier();
-                }
-            }
-
-            return false;
-        }
-
         void setInterfaceMethodTable(InterfaceMethodTable* set) { table = set; }
         InterfaceMethodTable* getInterfaceMethodTable() { return table; }
 };

--- a/include/hierarchy-checking/hierarchyChecking.h
+++ b/include/hierarchy-checking/hierarchyChecking.h
@@ -25,6 +25,10 @@ class HierarchyChecking {
         void classNotExtendFinalClass(CompilationTable* compilation);
         void checkMethodModifiers(CompilationTable* compilation);
         void checkForCycles(CompilationTable* compilation);
+
+        // To be called after checks
+        // Bring down inherited methods and fields from superclass (only for classes)
+        void establishInheritance(CompilationTable* compilation);
     public:
         HierarchyChecking(std::map<std::string, std::vector<CompilationTable*> >& packages);
 

--- a/include/sym-table/compilationTable.h
+++ b/include/sym-table/compilationTable.h
@@ -26,6 +26,7 @@ class CompilationTable {
         SymbolTable* symTable;
         std::string filename;
         CompilationUnit* unit;
+        bool established;
         // other compilations in the same package
         std::vector<CompilationTable*>* compilationsInPackage;
         // compilations from single type import
@@ -50,6 +51,12 @@ class CompilationTable {
 
         void checkMethodForOverlappingScope(ClassMethodTable* methodTable);
         void checkConstructorForOverlappingScope(ConstructorTable* constructorTable);
+
+        // Small helper during registering inherited fields and methods
+        // Called from function inheritFieldsAndMethods
+        void registerInheritedField(const std::string& field, FieldTable* table);
+        void registerInheritedClassMethod(const std::string& methodSignature, ClassMethodTable* table);
+
     public:
         CompilationTable(PackageDecl* package, const std::string& filename, CompilationUnit* unit);
         ~CompilationTable();
@@ -72,21 +79,22 @@ class CompilationTable {
         ClassMethodTable* getAClassMethod(const std::string& methodSignature);
         ConstructorTable* getAConstructor(const std::string& constructorSignature);
         void registerAField(const std::string& field, FieldTable* table);
-        void registerAClassMethod(const std::string& methodSignature, ClassMethodTable* table);
-        void registerAConstructor(const std::string& ctorSignature, ConstructorTable* table);
+        void registerClassMethodsAndConstructors();
         bool checkForFieldPresence(const std::string& field);
         bool checkForClassMethodPresence(const std::string& methodSignature);
         bool checkForConstructorPresence(const std::string& constructorSignature);
 
         // This part is to be called after hierarchy checking, involved with superclass extensions
-        void registerInheritedField(const std::string& field, FieldTable* table);
-        void registerInheritedClassMethod(const std::string& methodSignature, ClassMethodTable* table);
-        void inheritFieldsAndMethods(CompilationTable* child, CompilationTable* parent);
+        // Called to check if this compilation unit's inheritance have been properly resolved
+        // i.e methods and fields have been properly inherited, applies only to compilations of classes
+        bool isInheritanceEstablished();
+        // Called after registering class methods, fields and constructors
+        void inheritFieldsAndMethods();
 
         // ---------------------------------------------------------------------
         // Interface if symbol table is an interface table
         InterfaceMethodTable* getAnInterfaceMethod(const std::string& methodSignature);
-        void registerAnInterfaceMethod(const std::string& methodSignature, InterfaceMethodTable* table);
+        void registerInterfaceMethods();
         bool checkForInterfaceMethodPresence(const std::string& methodSignature);
 
         // ---------------------------------------------------------------------

--- a/include/sym-table/compilationTable.h
+++ b/include/sym-table/compilationTable.h
@@ -15,13 +15,11 @@ class LocalTable;
 class NestedBlockTable;
 class ForTable;
 class InterfaceMethodTable;
-class BuildCompilationTable;
 class ParamList;
 class Identifier;
 class Token;
 
 class CompilationTable {
-    friend class BuildCompilationTable;
     private:
         PackageDecl* package;
         // NULL if no type is defined
@@ -73,13 +71,22 @@ class CompilationTable {
         FieldTable* getAField(const std::string& field);
         ClassMethodTable* getAClassMethod(const std::string& methodSignature);
         ConstructorTable* getAConstructor(const std::string& constructorSignature);
+        void registerAField(const std::string& field, FieldTable* table);
+        void registerAClassMethod(const std::string& methodSignature, ClassMethodTable* table);
+        void registerAConstructor(const std::string& ctorSignature, ConstructorTable* table);
         bool checkForFieldPresence(const std::string& field);
         bool checkForClassMethodPresence(const std::string& methodSignature);
         bool checkForConstructorPresence(const std::string& constructorSignature);
 
+        // This part is to be called after hierarchy checking, involved with superclass extensions
+        void registerInheritedField(const std::string& field, FieldTable* table);
+        void registerInheritedClassMethod(const std::string& methodSignature, ClassMethodTable* table);
+        void inheritFieldsAndMethods(CompilationTable* child, CompilationTable* parent);
+
         // ---------------------------------------------------------------------
         // Interface if symbol table is an interface table
         InterfaceMethodTable* getAnInterfaceMethod(const std::string& methodSignature);
+        void registerAnInterfaceMethod(const std::string& methodSignature, InterfaceMethodTable* table);
         bool checkForInterfaceMethodPresence(const std::string& methodSignature);
 
         // ---------------------------------------------------------------------

--- a/include/weeds/NoAbstractFinal_impl.h
+++ b/include/weeds/NoAbstractFinal_impl.h
@@ -68,7 +68,7 @@ class NoAbstractFinal : public Weed
         {
             if (hasAbstractMod(node) && hasFinalMod(node)) {
                 std::stringstream ss;
-                ss << "class '" << getClassName(node) << "' cannot be declared as both final and abstract.";
+                ss << "Class '" << getClassName(node) << "' cannot be declared as both final and abstract.";
 
                 Error(E_WEEDER, token, ss.str());
             }

--- a/src/hierarchy-checking/hierarchyChecking.cpp
+++ b/src/hierarchy-checking/hierarchyChecking.cpp
@@ -266,6 +266,7 @@ void HierarchyChecking::OverrideChecks(CompilationTable* compilation) {
     std::set<std::string> public_methods;
     std::set<std::string> non_static_methods;
     std::set<std::string> static_methods;
+    std::set<std::string> abstract_methods;
     CompilationTable* processing;
     while (!traverse.empty()) {
         processing = traverse.front();
@@ -294,15 +295,23 @@ void HierarchyChecking::OverrideChecks(CompilationTable* compilation) {
                             MethodHeader* mh = static_cast<ClassMethod*>(cbd)->getMethodHeader();
                             std::string signature = mh->methodSignatureAsString();
 
-                            // Check Static vs. Instance Overriding
+                            // Check Static vs. Instance Overriding vs. Abstract overriding
                             if (cbd->isStatic()) {
                                 static_methods.insert(signature);
                                 
                                 if (non_static_methods.count(signature)) {
                                     std::stringstream ss;
                                     ss << "Static method '" << signature << "' in class '" << processing->getClassOrInterfaceName()
-                                       << "' cannot be overriden as a instance method.";
+                                       << "' cannot be overriden as an instance method.";
 
+                                    Error(E_HIERARCHY, token, ss.str());
+                                    break;
+                                }
+
+                                if(abstract_methods.count(signature)) {
+                                    std::stringstream ss;
+                                    ss << "Static method '" << signature << "' in class '" << processing->getClassOrInterfaceName()
+                                       << "' cannot be overriden as an abstract method.";
                                     Error(E_HIERARCHY, token, ss.str());
                                     break;
                                 }
@@ -330,6 +339,18 @@ void HierarchyChecking::OverrideChecks(CompilationTable* compilation) {
                                     ss << "Public method '" << signature << "' in class '" << processing->getClassOrInterfaceName()
                                        << "' cannot be overriden as protected.";
 
+                                    Error(E_HIERARCHY, token, ss.str());
+                                    break;
+                                }
+                            }
+
+                            // check Abstract vs. Static overriding
+                            if(cbd->isAbstract()) {
+                                abstract_methods.insert(signature);
+                                if(static_methods.count(signature)) {
+                                    std::stringstream ss;
+                                    ss << "Abstract method '" << signature << "' in class '" << processing->getClassOrInterfaceName()
+                                       << "' cannot be overriden or implemented as a static method.";
                                     Error(E_HIERARCHY, token, ss.str());
                                     break;
                                 }
@@ -370,45 +391,26 @@ void HierarchyChecking::OverrideChecks(CompilationTable* compilation) {
                     while (im != NULL) {
                         std::string signature = im->methodSignatureAsString();
 
-                        // Check Static vs. Instance Overriding
-                        if (im->isStatic()) {
-                            static_methods.insert(signature);
-                            
-                            if (non_static_methods.count(signature)) {
-                                std::stringstream ss;
-                                ss << "Static method '" << signature << "' in interface '" << processing->getClassOrInterfaceName()
-                                   << "' cannot be overriden as a instance method.";
+                        // Check Protected vs. Public Overriding, by default interface method is public
+                        public_methods.insert(signature);
 
-                                Error(E_HIERARCHY, token, ss.str());
-                                break;
-                            }
-                        } else {
-                            non_static_methods.insert(signature);
+                        if (protected_methods.count(signature)) {
+                            std::stringstream ss;
+                            ss << "Interface method '" << signature << "' in interface '" << processing->getClassOrInterfaceName()
+                               << "' cannot be overriden as protected.";
 
-                            if (static_methods.count(signature)) {
-                                std::stringstream ss;
-                                ss << "Instance method '" << signature << "' in interface '" << processing->getClassOrInterfaceName()
-                                   << "' cannot be overriden as a static method.";
-
-                                Error(E_HIERARCHY, token, ss.str());
-                                break;
-                            }
+                            Error(E_HIERARCHY, token, ss.str());
+                            break;
                         }
 
-                        // Check Protected vs. Public Overriding
-                        if (im->isProtected()) {
-                            protected_methods.insert(signature);
-                        } else {
-                            public_methods.insert(signature);
-
-                            if (protected_methods.count(signature)) {
-                                std::stringstream ss;
-                                ss << "Public method '" << signature << "' in class '" << processing->getClassOrInterfaceName()
-                                   << "' cannot be overriden as protected.";
-
-                                Error(E_HIERARCHY, token, ss.str());
-                                break;
-                            }
+                        // Check Abstract vs. Static overriding, by default interface methods are abstract
+                        abstract_methods.insert(signature);
+                        if(static_methods.count(signature)) {
+                            std::stringstream ss;
+                            ss << "Interface method '" << signature << "' in interface '" << processing->getClassOrInterfaceName()
+                               << "' cannot be overriden or implemented as static.";
+                            Error(E_HIERARCHY, token, ss.str());
+                            break;
                         }
 
                         im = im->getNextInterfaceMethod();
@@ -539,14 +541,25 @@ void HierarchyChecking::checkMethodModifiers(CompilationTable* compilation){
                                 Error(E_HIERARCHY, token, ss.str());
                                 break;
                             }
-                            if(methods.count(signature) == 0 && checkAbstract && cbd->isAbstract())
-                            {
-                                std::stringstream ss;
-                                ss << compilation->getClassOrInterfaceName() << ": Abstract method '" << signature << "' in class '" << processing->getClassOrInterfaceName()
-                                   << "' must be overriden.";
-                                Error(E_HIERARCHY, token, ss.str());
-                                break;
+
+                            if(checkAbstract) {
+                                if(processing == compilation) {
+                                    // if it's actually itself being checked
+                                    if(cbd->isAbstract()) {
+                                        std::stringstream ss;
+                                        ss << "Abstract method '" << signature << "' cannot be declared in class '"
+                                           << processing->getClassOrInterfaceName() << "' because the class is not abstract.";
+                                        Error(E_HIERARCHY, token, ss.str());
+                                    }
+                                } else if(methods.count(signature) == 0 && cbd->isAbstract()) {
+                                    std::stringstream ss;
+                                    ss << "Abstract method '" << signature << "' in class '" << processing->getClassOrInterfaceName()
+                                       << "' must be overriden.";
+                                    Error(E_HIERARCHY, token, ss.str());
+                                    break;
+                                }
                             }
+
                             if(mh->isVoidReturnType())
                             {
                                 methods[signature] = "";

--- a/src/sym-table/buildCompilationTable.cpp
+++ b/src/sym-table/buildCompilationTable.cpp
@@ -120,16 +120,7 @@ void BuildCompilationTable::build(FieldDecl& node) {
     table->setPrevTable(curSymTable);
     
     node.setFieldTable(table);
-    std::string field = node.getFieldDeclared()->getIdAsString();
-    if(curCompTable->fields.count(field) == 0) {
-        curCompTable->fields[field] = table;
-    } else {
-        std::stringstream ss;
-        Token* prevField = curCompTable->fields[field]->getField()->getFieldDeclared()->getToken();
-        ss << "Field '" << field << "' was previously defined here: "
-           << prevField->getFile() << ":" << prevField->getLocation().first << ":" << prevField->getLocation().second;
-        Error(E_SYMTABLE, node.getFieldDeclared()->getToken(), ss.str());
-    }
+    curCompTable->registerAField(node.getFieldDeclared()->getIdAsString(), table); 
     curSymTable = table;
 }
 
@@ -143,19 +134,6 @@ void BuildCompilationTable::build(ClassMethod& node) {
     build(*node.getMethodBody());
     
     node.setClassMethodTable(table);
-    std::string methodSignature = node.getMethodHeader()->methodSignatureAsString();
-    if(curCompTable->classMethods.count(methodSignature) == 0) {
-        // if a method with this particular signature is not registered yet
-        curCompTable->classMethods[methodSignature] = table;
-    } else {
-        // error out
-        std::stringstream ss;
-        Token* prevMethod = curCompTable->classMethods[methodSignature]
-                            ->getClassMethod()->getMethodHeader()->getClassMethodId()->getToken();
-        ss << "Class method '" << methodSignature << "' was previously defined here: "
-           << prevMethod->getFile() << ":" << prevMethod->getLocation().first << ":" << prevMethod->getLocation().second;
-        Error(E_SYMTABLE, node.getMethodHeader()->getClassMethodId()->getToken(), ss.str());
-    }
     curSymTable = tempTable;
 }
 
@@ -229,18 +207,6 @@ void BuildCompilationTable::build(Constructor& node) {
     build(*node.getConstructorBody());
     
     node.setConstructorTable(table);
-    std::string constructorSignature = node.constructorSignatureAsString();
-    if(curCompTable->constructors.count(constructorSignature) == 0) {
-        // if a constructor with this signature is not registered yet
-        curCompTable->constructors[constructorSignature] = table;
-    } else {
-        std::stringstream ss;
-        Token* prevCtor = curCompTable->constructors[constructorSignature]->getConstructor()->getConstructorId()->getToken();
-        ss << "Constructor '" << constructorSignature << "' was previously defined here: "
-           << prevCtor->getFile() << ":" << prevCtor->getLocation().first << ":" << prevCtor->getLocation().second;
-        Error(E_SYMTABLE, node.getConstructorId()->getToken(), ss.str());
-    }
-
     curSymTable = tempTable;
 }
 
@@ -270,16 +236,6 @@ void BuildCompilationTable::build(InterfaceMethod& node) {
     table->setPrevTable(curSymTable);
     
     node.setInterfaceMethodTable(table);
-    std::string methodSignature = node.methodSignatureAsString();
-    if(curCompTable->interfaceMethods.count(methodSignature) == 0) {
-        curCompTable->interfaceMethods[methodSignature] = table;
-    } else {
-        std::stringstream ss;
-        Token* prevMethod = curCompTable->interfaceMethods[methodSignature]->getInterfaceMethod()->getInterfaceMethodId()->getToken();
-        ss << "Interface method '" << methodSignature << "' was previously defined here: "
-           << prevMethod->getFile() << ":" << prevMethod->getLocation().first << ":" << prevMethod->getLocation().second;
-        Error(E_SYMTABLE, node.getInterfaceMethodId()->getToken(), ss.str());
-    }
     curSymTable = table;
 }
 

--- a/src/sym-table/compilationTable.cpp
+++ b/src/sym-table/compilationTable.cpp
@@ -19,7 +19,7 @@
 #include "error.h"
 
 CompilationTable::CompilationTable(PackageDecl* package, const std::string& filename, CompilationUnit* unit) : package(package),
-                symTable(NULL), filename(filename), unit(unit), compilationsInPackage(NULL) {}
+                symTable(NULL), filename(filename), unit(unit), established(false), compilationsInPackage(NULL) {}
 
 CompilationTable::~CompilationTable() {
     delete symTable;
@@ -140,40 +140,85 @@ void CompilationTable::registerAField(const std::string& field, FieldTable* tabl
     }
 }
 
-void CompilationTable::registerAClassMethod(const std::string& methodSignature, ClassMethodTable* table) {
+void CompilationTable::registerClassMethodsAndConstructors() {
     // called after the hierarchy checking stage
     // assume that the hierarchy checking stage has checked for duplicate methods
-    classMethods[methodSignature] = table;
-}
+    SymbolTable* table = symTable;
+    if(table != NULL) {
+        // a type was defined
+        // precautionary check that the symbol table is indeed a class table
+        assert(symTable->isClassTable());
+        table = table->getNextTable();
+        while(table != NULL) {
+            if(table->isClassMethodTable()) {
+                ClassMethodTable* methodTable = (ClassMethodTable*) table;
+                classMethods[methodTable->getClassMethod()->getMethodHeader()->methodSignatureAsString()] = methodTable;
+            } else if(table->isConstructorTable()) {
+                ConstructorTable* ctorTable = (ConstructorTable*) table;
+                constructors[ctorTable->getConstructor()->constructorSignatureAsString()] = ctorTable;
+            }
 
-void CompilationTable::registerAConstructor(const std::string& ctorSignature, ConstructorTable* table) {
-    // assumptions hold the same way as registerAClassMethod
-    constructors[ctorSignature] = table;
+            table = table->getNextTable();
+        }
+    }
 }
 
 bool CompilationTable::checkForFieldPresence(const std::string& field) {
     assert(symTable->isClassTable());
-    return fields[field];
+    return fields.count(field);
 }
 
 bool CompilationTable::checkForClassMethodPresence(const std::string& methodSignature) {
     assert(symTable->isClassTable());
-    return classMethods.count(methodSignature) == 1;
+    return classMethods.count(methodSignature);
 }
 
 bool CompilationTable::checkForConstructorPresence(const std::string& constructorSignature) {
     assert(symTable->isClassTable());
-    return constructors.count(constructorSignature) == 1;
+    return constructors.count(constructorSignature);
 }
 
 // To be called after hierarchy checking
-void registerInheritedField(const std::string& field, FieldTable* table) {
+void CompilationTable::registerInheritedField(const std::string& field, FieldTable* table) {
+    if(fields.count(field) == 0) {
+        // is not overriden
+        fields[field] = table;
+    }
 }
 
-void registerInheritedClassMethod(const std::string& methodSignature, ClassMethodTable* table) {
+void CompilationTable::registerInheritedClassMethod(const std::string& methodSignature, ClassMethodTable* table) {
+    if(classMethods.count(methodSignature) == 0) {
+        // is not overriden
+        classMethods[methodSignature] = table;
+    }
 }
 
-void inheritFieldsAndMethods(CompilationTable* child, CompilationTable* parent) {
+bool CompilationTable::isInheritanceEstablished() {
+    // precautionary check that this is called for a class table
+    assert(symTable->isClassTable());
+    return established;
+}
+
+void CompilationTable::inheritFieldsAndMethods() {
+    // precautionary check that the symbol table is indeed a class table
+    assert(symTable->isClassTable());
+    std::map<std::string, FieldTable*>::iterator fieldIt;
+    std::map<std::string, ClassMethodTable*>::iterator methodIt;
+    CompilationTable* parent = ((ClassTable*) symTable)->getClass()->getSuper()->getSuperClassTable();
+    if(parent != NULL) {
+        // if there was actually a superclass inherited
+        // only case there is none is for java.lang.Object
+        for(fieldIt = parent->fields.begin(); fieldIt != parent->fields.end(); fieldIt++) {
+            registerInheritedField(fieldIt->second->getField()->getFieldDeclared()->getIdAsString(), fieldIt->second);
+        }
+
+        for(methodIt = parent->classMethods.begin(); methodIt != parent->classMethods.end(); methodIt++) {
+            registerInheritedClassMethod(methodIt->second->getClassMethod()->getMethodHeader()->methodSignatureAsString(),
+                                         methodIt->second);
+        }
+    }
+    // indicate that inheritance have been properly done
+    established = true;
 }
 
 // ---------------------------------------------------------------------
@@ -183,14 +228,24 @@ InterfaceMethodTable* CompilationTable::getAnInterfaceMethod(const std::string& 
     return interfaceMethods[methodSignature];
 }
 
-void CompilationTable::registerAnInterfaceMethod(const std::string& methodSignature, InterfaceMethodTable* table) {
-    // assumptions hold the same way as registerAClassMethod
-    interfaceMethods[methodSignature] = table;
+void CompilationTable::registerInterfaceMethods() {
+    // assumptions hold the same way as registerClassMethodsAndConstructor
+    if(symTable != NULL) {
+        // a type was defined
+        // precautionary check that the symbol table is indeed an interface table
+        assert(symTable->isInterfaceTable());
+        // by default we know the next symbol table must be an InterfaceMethodTable
+        InterfaceMethodTable* methodTable = (InterfaceMethodTable*) symTable->getNextTable();
+        while(methodTable != NULL) {
+            interfaceMethods[methodTable->getInterfaceMethod()->methodSignatureAsString()] = methodTable;
+            methodTable = (InterfaceMethodTable*) methodTable->getNextTable();
+        }
+    }
 }
 
 bool CompilationTable::checkForInterfaceMethodPresence(const std::string& methodSignature) {
     assert(symTable->isInterfaceTable());
-    return interfaceMethods.count(methodSignature) == 1;
+    return interfaceMethods.count(methodSignature);
 }
 
 //----------------------------------------------------------------------

--- a/src/type-link/typeLinker.cpp
+++ b/src/type-link/typeLinker.cpp
@@ -490,6 +490,11 @@ void TypeLinker::linkTypeNames(CompilationTable* compilation, NewClassCreation* 
                                 create->getClassName()->getNameId()->getToken());
     }
 
+    if(linkType->aTypeWasDefined() && !linkType->isClassSymbolTable()) {
+        std::stringstream ss;
+        ss << "Cannot create interface '" << create->getClassName()->getFullName() << "' through a class instance creation expression.";
+        Error(E_TYPELINKING, create->getClassName()->getNameId()->getToken(), ss.str());
+    }
     create->setTableOfCreatedClass(linkType);
 }
 
@@ -659,7 +664,7 @@ CompilationTable* TypeLinker::linkTypeNames(CompilationTable* compilation, Name*
             if(!typeExist) { return NULL; }
             if(checkIfNameConflictsWithType(compilation, name->getNextName(), true)) {
                 std::stringstream ss;
-                ss << "Fully qualified name '" << qualifier+typeName
+                ss << "Fully qualified name '" << name->getFullName()
                    << "' resolves to a type, but it's strict prefix is also a type itself in this compilation unit's environment.";
                 Error(E_TYPELINKING, name->getNameId()->getToken(), ss.str());
             }


### PR DESCRIPTION
- Made sure to check for conflicting abstract and static methods overriding.
- Deleted isProtected, isFinal and isStatic from Interface Method AST node since final, protected and static modifiers are inherently impossible for interfaces.
- Reflected the fact that interface methods are inherently public and abstract in hierarchy checking's checkMethodModifiers function.
- Compilation tables of classes now have methods and fields from superclasses. Compilation table of interfaces can be made to do so too with current functions, but right now they do not because there seems to be of no use yet for them.
