### PR TITLE
Hotfix patch + additional things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for joos compiler
 CC=g++
-CFLAGS=-std=c++0x -c -Wall -I./include -I./include/dfas -I./include/weeds -I./include/AST -I./include/sym-table -I./include/type-link -I./include/hierarchy-checking -I./include/disambiguate -I./include/type-checking -I./include/reachability
+CFLAGS=-std=c++0x -c -Wall -I./include -I./include/dfas -I./include/weeds -I./include/AST -I./include/sym-table -I./include/type-link -I./include/hierarchy-checking -I./include/disambiguate -I./include/type-checking -I./include/reachability -I./include/code-gen/startup
 BUILD_DIR=build/src
 OUT_FILE=joosc
 
@@ -39,20 +39,24 @@ TYPECHECK_O = $(addprefix build/src/type-checking/, $(notdir $(TYPECHECK_C:.cpp=
 REACHABILITY_C = $(wildcard src/reachability/*.cpp)
 REACHABILITY_O = $(addprefix build/src/reachability/, $(notdir $(REACHABILITY_C:.cpp=.o)))
 
+# CODE GENERATION CODE
+STARTUP_C = $(wildcard src/code-gen/startup/*.cpp)
+STARTUP_O = $(addprefix build/src/code-gen/startup/, $(notdir $(STARTUP_C:.cpp=.o)))
+
 # Main Code
 SRC_C = $(wildcard src/*.cpp)
 SRC_O = $(addprefix build/src/, $(notdir $(SRC_C:.cpp=.o))) $(DFA_O) $(AST_O) $(SYMTABLE_O) $(TYPELINK_O) $(HC_O) $(DIS_O) $(TYPECHECK_O)\
-       	$(REACHABILITY_O)
+       	$(REACHABILITY_O) $(STARTUP_O)
 
 # Test Code
 TEST_C = $(wildcard tests/src/*.cpp)
 TEST_O = $(addprefix build/tests/, $(notdir $(TEST_C:.cpp=.o)))
-TEST_CFLAGS=-std=c++0x -c -Wall -I./include -I./tests/include -I./include/dfas -I./include/weeds -I./include/AST -I./include/sym-table -I./include/type-link -I./include/hierarchy-checking -I./include/disambiguate -I./include/type-checking -I./include/reachability
+TEST_CFLAGS=-std=c++0x -c -Wall -I./include -I./tests/include -I./include/dfas -I./include/weeds -I./include/AST -I./include/sym-table -I./include/type-link -I./include/hierarchy-checking -I./include/disambiguate -I./include/type-checking -I./include/reachability -I./include/code-gen/startup
 TEST_LIB_PATH=-L build/lib -l joos
 TEST_OUT_FILE=test_joosc
 
 # Include
-SRC_INC = $(wildcard include/*.h) $(wildcard include/dfas/*.h) $(wildcard include/weeds/*.h) $(wildcard include/AST/*.h) $(wildcard include/sym-table/*.h) $(wildcard include/type-link/*.h) $(wildcard include/hierarchy-checking/*.h) $(wildcard include/disambiguate/*.h) $(wildcard include/type-checking/*.h) $(wildcard include/reachability/*.h)
+SRC_INC = $(wildcard include/*.h) $(wildcard include/dfas/*.h) $(wildcard include/weeds/*.h) $(wildcard include/AST/*.h) $(wildcard include/sym-table/*.h) $(wildcard include/type-link/*.h) $(wildcard include/hierarchy-checking/*.h) $(wildcard include/disambiguate/*.h) $(wildcard include/type-checking/*.h) $(wildcard include/reachability/*.h) $(wildcard include/code-gen/startup/*.h)
 TEST_INC = $(wildcard tests/include/*.h)
 
 # Static Lib for Tests
@@ -69,7 +73,7 @@ compiler: init $(OUT_FILE)
 tests: init $(TEST_OUT_FILE)
 
 init:
-	@mkdir -p $(BUILD_DIR) $(BUILD_DIR)/dfas $(BUILD_DIR)/AST $(BUILD_DIR)/sym-table $(BUILD_DIR)/type-link build/tests build/lib $(BUILD_DIR)/hierarchy-checking $(BUILD_DIR)/disambiguate $(BUILD_DIR)/type-checking $(BUILD_DIR)/reachability
+	@mkdir -p $(BUILD_DIR) $(BUILD_DIR)/dfas $(BUILD_DIR)/AST $(BUILD_DIR)/sym-table $(BUILD_DIR)/type-link build/tests build/lib $(BUILD_DIR)/hierarchy-checking $(BUILD_DIR)/disambiguate $(BUILD_DIR)/type-checking $(BUILD_DIR)/reachability $(BUILD_DIR)/code-gen/startup
 	@$(foreach TEST_CASE, $(TEST_CASES), python Extras/Scripts/listTestFiles.py tests/$(TEST_CASE)/ tests/include/$(TEST_CASE)TestFiles.h  tests/src/$(TEST_CASE)TestFiles.cpp $(TEST_CASE);)
 	# @python Extras/Scripts/readParserRulesAndTable.py Extras/Grammar/grammarAndParseTable.txt include/parserRules.h src/parserRules.cpp include/parserActions.h src/parserActions.cpp
 
@@ -97,6 +101,9 @@ build/src/type-checking/%.o: src/type-checking/%.cpp $(SRC_INC)
 
 build/src/reachability/%.o: src/reachability/%.cpp $(SRC_INC)
 	$(CC) $(CFLAGS) $< -o $(BUILD_DIR)/reachability/$(notdir $(@:.cpp=.o))
+
+build/src/code-gen/startup/%.o: src/code-gen/startup/%.cpp $(SRC_INC)
+	$(CC) $(CFLAGS) $< -o $(BUILD_DIR)/code-gen/startup/$(notdir $(@:.cpp=.o))
 
 build/src/%.o: src/%.cpp $(SRC_INC)
 	$(CC) $(CFLAGS) $< -o $(BUILD_DIR)/$(notdir $(@:.cpp=.o))

--- a/include/code-gen/startup/startup.h
+++ b/include/code-gen/startup/startup.h
@@ -6,20 +6,50 @@
 #include <string>
 
 class CompilationTable;
+class ClassMethodTable;
 
 class Startup {
     private:
         unsigned int typeCounter;
         unsigned int numOfTypes;
+        unsigned int interfaceMethodCounter;
+        unsigned int numOfInterfaceMethods;
         std::map<std::string, CompilationTable*>& compilations;
+        // pointer to java.lang.Object
+        CompilationTable* object;
+
+        // inheritance related
+        // mapping structure: canonical name -> index in std::vector<bool> of inheritanceTable
         std::map<std::string, unsigned int> typeMapping;
+        // mapping structure: canonical name -> a vector of booleans that represent
+        // whether the type (represented by the canonical name) is a subtype (subclass/subinterface)
+        // of the type represented at some index i, where i is mapped to the canonical name of some type
+        // in typeMapping
         std::map<std::string, std::vector<bool> > inheritanceTable;
 
-        void copyInheritanceTable(const std::string& targetName, const std::string& sourceName);
-        void printInheritanceTable();
+        // interface method related
+        // mapping structure: method signature -> index in std::vector<ClassMethodTable*> of interfaceMethodTable
+        std::map<std::string, unsigned int> interfaceMethodsMapping;
+        // mapping structure: method signature -> a vector of the interfaces that declared the method with
+        // the particular signature
+        std::map<std::string, std::vector<CompilationTable*> > interfaceMethodsDeclaredIn;
+        // mapping structure: canonical names (only classes) -> a vector of the ClassMethodTable* that each
+        // represents the class method that implements the interface methods represented at some index i,
+        // where i is mapped to an interface method in interfaceMethodsMapping
+        std::map<std::string, std::vector<ClassMethodTable*> > interfaceMethodTable;
+
+        void copyInheritanceTable(const std::string&, const std::string&);
+        void copyInterfaceMethodTable(const std::string&, const std::string&);
         void buildInheritanceTable(CompilationTable*);
+        void setAllInterfaceMethods();
+        void buildInterfaceMethodTable(CompilationTable*);
+
+        // --------------------------------------------------------------
+        // miscellaneous
+        void printInheritanceTable();
+        void printInterfaceMethodTable();
     public:
-        Startup(std::map<std::string, CompilationTable*>& compilations);
+        Startup(std::map<std::string, CompilationTable*>&);
         void buildTables();
 };
 

--- a/include/code-gen/startup/startup.h
+++ b/include/code-gen/startup/startup.h
@@ -1,0 +1,26 @@
+#ifndef __STARTUP_H__
+#define __STARTUP_H__
+
+#include <map>
+#include <vector>
+#include <string>
+
+class CompilationTable;
+
+class Startup {
+    private:
+        unsigned int typeCounter;
+        unsigned int numOfTypes;
+        std::map<std::string, CompilationTable*>& compilations;
+        std::map<std::string, unsigned int> typeMapping;
+        std::map<std::string, std::vector<bool> > inheritanceTable;
+
+        void copyInheritanceTable(const std::string& targetName, const std::string& sourceName);
+        void printInheritanceTable();
+        void buildInheritanceTable(CompilationTable*);
+    public:
+        Startup(std::map<std::string, CompilationTable*>& compilations);
+        void buildTables();
+};
+
+#endif

--- a/include/sym-table/compilationTable.h
+++ b/include/sym-table/compilationTable.h
@@ -48,6 +48,7 @@ class CompilationTable {
         std::map<std::string, FieldTable*> fields;
 
         std::map<std::string, ClassMethodTable*> inheritedClassMethods;
+        std::map<std::string, InterfaceMethodTable*> inheritedInterfaceMethodsForClass;
         std::map<std::string, FieldTable*> inheritedFields;
         
         // mappings for interface methods, includes inherited ones
@@ -70,6 +71,7 @@ class CompilationTable {
         // Called from function inheritClassFieldsAndMethods
         void registerInheritedField(const std::string& field, FieldTable* table);
         void registerInheritedClassMethod(const std::string& methodSignature, ClassMethodTable* table);
+        void registerInheritedInterfaceMethodsForClass(const std::string& methodSignature, InterfaceMethodTable* table);
         // Small helper during registering inherited interface methods
         // Called from function inheritInterfaceMethods
         void registerInheritedInterfaceMethod(const std::string& methodSignature, InterfaceMethodTable* table);
@@ -98,8 +100,10 @@ class CompilationTable {
         std::map<std::string, FieldTable*>& getAllFieldsInClass();
         std::map<std::string, FieldTable*>& getAllFieldsInherited();
         ClassMethodTable* getAClassMethod(const std::string& methodSignature);
+        InterfaceMethodTable* getInterfaceMethodFromClass(const std::string& methodSignature);
         std::map<std::string, ClassMethodTable*>& getAllClassMethodsInClass();
         std::map<std::string, ClassMethodTable*>& getAllClassMethodsInherited();
+        std::map<std::string, InterfaceMethodTable*>& getAllInheritedInterfaceMethodsForClass();
         bool classMethodIsInherited(const std::string& methodSignature);
         ConstructorTable* getAConstructor(const std::string& constructorSignature);
         void registerAField(const std::string& field, FieldTable* table);

--- a/include/sym-table/compilationTable.h
+++ b/include/sym-table/compilationTable.h
@@ -31,6 +31,11 @@ class CompilationTable {
         // for the purposes of interfaces
         CompilationTable* extendFromObject;
         bool established;
+        // number of corresponding members defined in the type
+        // defined in this compilation unit (not including inherited ones)
+        unsigned int numFields;
+        unsigned int numClassMethods;
+        unsigned int numInterfaceMethods;
         // other compilations in the same package
         std::vector<CompilationTable*>* compilationsInPackage;
         // compilations from single type import
@@ -44,8 +49,10 @@ class CompilationTable {
 
         std::map<std::string, ClassMethodTable*> inheritedClassMethods;
         std::map<std::string, FieldTable*> inheritedFields;
-        // mappings for interface methods
+        
+        // mappings for interface methods, includes inherited ones
         std::map<std::string, InterfaceMethodTable*> interfaceMethods;
+        std::map<std::string, InterfaceMethodTable*> inheritedInterfaceMethods;
 
         void reportLocalError(const std::string& conflict, const std::string& entity, Token* prevToken, Token* currToken);
         void iterateThroughTable(SymbolTable* table, std::vector<std::map<std::string, Token*>* >& blockScopes);
@@ -130,6 +137,18 @@ class CompilationTable {
         CompilationTable* checkTypePresenceFromSingleImport(const std::string& typeName);
         CompilationTable* checkTypePresenceInPackage(const std::string& typeName);
         CompilationTable* checkTypePresenceFromImportOnDemand(const std::string& typeName, Token* tokName);
+
+        // ---------------------------------------------------------------------
+        // Interface to get all fields/methods defined in this type
+        std::map<std::string, ClassMethodTable*>& getDefinedClassMethods();
+        std::map<std::string, FieldTable*>& getDefinedFields();
+        std::map<std::string, InterfaceMethodTable*>& getDefinedInterfaceMethods();
+
+        // ---------------------------------------------------------------------
+        // Interface to get the number of fields/methods defined in this type
+        unsigned int getNumDefinedFields();
+        unsigned int getNumDefinedClassMethods();
+        unsigned int getNumDefinedInterfaceMethods();
 };
 
 #endif

--- a/src/code-gen/startup/startup.cpp
+++ b/src/code-gen/startup/startup.cpp
@@ -1,0 +1,111 @@
+#include "startup.h"
+
+#include "compilationTable.h"
+#include "classTable.h"
+#include "interfaceTable.h"
+#include "classDecl.h"
+#include "interfaceDecl.h"
+
+Startup::Startup(std::map<std::string, CompilationTable*>& compilations) : typeCounter(0), numOfTypes(0),
+            compilations(compilations) {
+    std::map<std::string, CompilationTable*>::iterator it;
+    for(it = compilations.begin(); it != compilations.end(); it++) {
+        if(it->second->aTypeWasDefined()) {
+            // for every type defined, increment
+            numOfTypes++;
+        }
+    }
+    // increment once more for array types
+    numOfTypes++;
+}
+
+void Startup::buildTables() {
+    std::map<std::string, CompilationTable*>::iterator it;
+    for(it = compilations.begin(); it != compilations.end(); it++) {
+        buildInheritanceTable(it->second);
+    }
+   
+    // array types inheritance
+    typeMapping[".array"] = typeCounter;
+    for(unsigned int i = 0; i < numOfTypes; i++) {
+        inheritanceTable[".array"].push_back(false);
+    }
+    // arrays inherit from java.lang.Object
+    inheritanceTable[".array"][typeMapping["java.lang.Object"]] = true;
+    // arrays inherit self
+    inheritanceTable[".array"][typeCounter] = true;
+    // printInheritanceTable();
+}
+
+void Startup::copyInheritanceTable(const std::string& targetName, const std::string& sourceName) {
+    for(unsigned int i = 0; i < numOfTypes; i++) {
+        if(!inheritanceTable[targetName][i]) {
+            // only if inheritance entry is false, so that inheritance information
+            // isn't overriden
+            inheritanceTable[targetName][i] = inheritanceTable[sourceName][i];
+        }
+    }
+}
+
+void Startup::printInheritanceTable() {
+    std::map<std::string, std::vector<bool> >::iterator it;
+    for(it = inheritanceTable.begin(); it != inheritanceTable.end(); it++) {
+        std::cout << it->first;
+        for(unsigned int i = 0; i < numOfTypes; i++) {
+            std::cout << " " << it->second[i];
+        }
+        std::cout << std::endl;
+    }
+}
+
+void Startup::buildInheritanceTable(CompilationTable* table) {
+    if(table->aTypeWasDefined()) {
+        std::string canonicalName = table->getCanonicalName();
+        // return imediately if inheritance table have been created
+        // for this type
+        if(inheritanceTable.count(canonicalName) == 1) { return; }
+
+        for(unsigned int i = 0; i < numOfTypes; i++) {
+            // by default set everything to false
+            inheritanceTable[canonicalName].push_back(false);
+        }
+
+        // give a mapping for this type
+        typeMapping[canonicalName] = typeCounter;
+        typeCounter++;
+
+        if(table->isClassSymbolTable()) {
+            ClassDecl* aClass = ((ClassTable*) table->getSymbolTable())->getClass();
+            Super* superClass = aClass->getSuper();
+            if(!superClass->isEpsilon() || superClass->isImplicitlyExtending()) {
+                // create inheritance table for superclass
+                buildInheritanceTable(aClass->getSuper()->getSuperClassTable());
+                std::string superClassCanonicalName = aClass->getSuper()->getSuperClassTable()->getCanonicalName();
+                // copy inheritance table from superclass
+                copyInheritanceTable(canonicalName, superClassCanonicalName);
+            }
+        }
+       
+        Interfaces* implOrExtInterface = NULL;
+        if(table->isClassSymbolTable()) {
+            ClassDecl* aClass = ((ClassTable*) table->getSymbolTable())->getClass();
+            implOrExtInterface = aClass->getImplementInterfaces()->getListOfInterfaces();
+        } else {
+            InterfaceDecl* anInterface = ((InterfaceTable*) table->getSymbolTable())->getInterface();
+            implOrExtInterface = anInterface->getExtendedInterfaces()->getListOfInterfaces();
+        }
+
+        while(implOrExtInterface != NULL) {
+            // for each superinterface
+            // create inheritance table for superinterfaces
+            buildInheritanceTable(implOrExtInterface->getImplOrExtInterfaceTable());
+            std::string superInterfaceCanonicalName = implOrExtInterface->getImplOrExtInterfaceTable()->getCanonicalName();
+            // copy inheritance table from superinterfaces
+            copyInheritanceTable(canonicalName, superInterfaceCanonicalName);
+            implOrExtInterface = implOrExtInterface->getNextInterface();
+        }
+
+        // establish inheritance for self
+        inheritanceTable[canonicalName][typeMapping[canonicalName]] = true;
+    }
+}

--- a/src/code-gen/startup/startup.cpp
+++ b/src/code-gen/startup/startup.cpp
@@ -5,14 +5,22 @@
 #include "interfaceTable.h"
 #include "classDecl.h"
 #include "interfaceDecl.h"
+#include "classMethodTable.h"
+#include "classMethod.h"
+
+class InterfaceMethodTable;
 
 Startup::Startup(std::map<std::string, CompilationTable*>& compilations) : typeCounter(0), numOfTypes(0),
-            compilations(compilations) {
+            interfaceMethodCounter(0), numOfInterfaceMethods(0), compilations(compilations) {
     std::map<std::string, CompilationTable*>::iterator it;
+    setAllInterfaceMethods();
     for(it = compilations.begin(); it != compilations.end(); it++) {
         if(it->second->aTypeWasDefined()) {
             // for every type defined, increment
             numOfTypes++;
+            if(it->second->getCanonicalName() == "java.lang.Object") {
+                object = it->second;
+            }
         }
     }
     // increment once more for array types
@@ -20,21 +28,34 @@ Startup::Startup(std::map<std::string, CompilationTable*>& compilations) : typeC
 }
 
 void Startup::buildTables() {
-    std::map<std::string, CompilationTable*>::iterator it;
-    for(it = compilations.begin(); it != compilations.end(); it++) {
-        buildInheritanceTable(it->second);
-    }
-   
     // array types inheritance
     typeMapping[".array"] = typeCounter;
     for(unsigned int i = 0; i < numOfTypes; i++) {
         inheritanceTable[".array"].push_back(false);
     }
-    // arrays inherit from java.lang.Object
+    // arrays inherit from java.lang.Object and implements
+    // java.io.Serializable and java.lang.Cloneable
     inheritanceTable[".array"][typeMapping["java.lang.Object"]] = true;
+    inheritanceTable[".array"][typeMapping["java.lang.Cloneable"]] = true;
+    inheritanceTable[".array"][typeMapping["java.io.Serializable"]] = true;
     // arrays inherit self
     inheritanceTable[".array"][typeCounter] = true;
+    
+    std::map<std::string, CompilationTable*>::iterator it;
+    for(it = compilations.begin(); it != compilations.end(); it++) {
+        // preserve this order
+        buildInheritanceTable(it->second);
+        buildInterfaceMethodTable(it->second);
+    }
+
+    // array types interface method table
+    for(unsigned int i = 0; i < numOfInterfaceMethods; i++) {
+        interfaceMethodTable[".array"].push_back(NULL);
+    }
+
+    copyInterfaceMethodTable(".array", "java.lang.Object");
     // printInheritanceTable();
+    // printInterfaceMethodTable();
 }
 
 void Startup::copyInheritanceTable(const std::string& targetName, const std::string& sourceName) {
@@ -47,14 +68,12 @@ void Startup::copyInheritanceTable(const std::string& targetName, const std::str
     }
 }
 
-void Startup::printInheritanceTable() {
-    std::map<std::string, std::vector<bool> >::iterator it;
-    for(it = inheritanceTable.begin(); it != inheritanceTable.end(); it++) {
-        std::cout << it->first;
-        for(unsigned int i = 0; i < numOfTypes; i++) {
-            std::cout << " " << it->second[i];
+void Startup::copyInterfaceMethodTable(const std::string& targetName, const std::string& sourceName) {
+    for(unsigned int i = 0; i < numOfInterfaceMethods; i++) {
+        if(interfaceMethodTable[targetName][i] == NULL) {
+            // don't override non-NULL entries
+            interfaceMethodTable[targetName][i] = interfaceMethodTable[sourceName][i];
         }
-        std::cout << std::endl;
     }
 }
 
@@ -107,5 +126,123 @@ void Startup::buildInheritanceTable(CompilationTable* table) {
 
         // establish inheritance for self
         inheritanceTable[canonicalName][typeMapping[canonicalName]] = true;
+    }
+}
+
+void Startup::setAllInterfaceMethods() {
+    std::map<std::string, CompilationTable*>::iterator it;
+    for(it = compilations.begin(); it!= compilations.end(); it++) {
+        if(it->second->aTypeWasDefined()) {
+            if(!it->second->isClassSymbolTable()) {
+                // an interface
+                CompilationTable* interface = it->second;
+                std::map<std::string, InterfaceMethodTable*>& methods = interface->getDefinedInterfaceMethods();
+                std::map<std::string, InterfaceMethodTable*>::iterator it2;
+                for(it2 = methods.begin(); it2 != methods.end(); it2++) {
+                    std::string methodSignature = it2->first;
+                    if(interfaceMethodsMapping.count(methodSignature) == 0) {
+                        // not in the mapping, add to it and increase counter
+                        interfaceMethodsMapping[methodSignature] = interfaceMethodCounter;
+                        interfaceMethodCounter++;
+                    }
+                    interfaceMethodsDeclaredIn[methodSignature].push_back(interface);
+                }
+                numOfInterfaceMethods+= interface->getNumDefinedInterfaceMethods();
+            }
+
+            // special case, since interface 'inherits' from java.lang.Object
+            if(it->second->getCanonicalName() == "java.lang.Object") {
+                CompilationTable* object = it->second;
+                std::map<std::string, ClassMethodTable*>& methods = object->getDefinedClassMethods();
+                std::map<std::string, ClassMethodTable*>::iterator it2;
+                for(it2 = methods.begin(); it2 != methods.end(); it2++) {
+                    std::string methodSignature = it2->first;
+                    if(interfaceMethodsMapping.count(methodSignature) == 0) {
+                        interfaceMethodsMapping[methodSignature] = interfaceMethodCounter;
+                        interfaceMethodCounter++;
+                    }
+                    interfaceMethodsDeclaredIn[methodSignature].push_back(object);
+                }
+                numOfInterfaceMethods+= object->getNumDefinedClassMethods();
+            }
+        }
+    }
+}
+
+void Startup::buildInterfaceMethodTable(CompilationTable* table) {
+    if(table->aTypeWasDefined()) {
+        if(table->isClassSymbolTable()) {
+            // it's a class
+            std::string canonicalName = table->getCanonicalName();
+            // immediately return if the interface method table for this
+            // class has been created already
+            if(interfaceMethodTable.count(canonicalName) == 1) { return; }
+           
+            // initialize first for this class
+            for(unsigned int i = 0; i < numOfInterfaceMethods; i++) {
+                interfaceMethodTable[canonicalName].push_back(NULL);
+            }
+
+            Super* superClass = ((ClassTable*) table->getSymbolTable())->getClass()->getSuper();
+            if(!superClass->isEpsilon() || superClass->isImplicitlyExtending()) {
+                // recurse first for superclass, including for java.lang.Object
+                // even though java.lang.Object doesn't really implement interface
+                // classes, but it's still needed
+                buildInterfaceMethodTable(superClass->getSuperClassTable());
+                std::string superClassCanonicalName = superClass->getSuperClassTable()->getCanonicalName();
+                copyInterfaceMethodTable(canonicalName, superClassCanonicalName);
+            }
+
+            std::map<std::string, ClassMethodTable*>& methods = table->getDefinedClassMethods();
+            std::map<std::string, ClassMethodTable*>::iterator it;
+            for(it = methods.begin(); it != methods.end(); it++) {
+                std::string methodSignature = it->first;
+                if(interfaceMethodsMapping.count(methodSignature) == 1) {
+                    // if the method can be found in the interface methods mapping
+                    std::vector<CompilationTable*>::iterator it2;
+                    for(it2 = interfaceMethodsDeclaredIn[methodSignature].begin();
+                        it2 != interfaceMethodsDeclaredIn[methodSignature].end(); it2++) {
+                        std::string targetCanonicalName = (*it2)->getCanonicalName();
+                        if(inheritanceTable[canonicalName][typeMapping[targetCanonicalName]]) {
+                            // if current class is a subclass of one of the interfaces that
+                            // declares this method then register this class method into the interface method table
+                            interfaceMethodTable[canonicalName][interfaceMethodsMapping[methodSignature]] = it->second;
+                            // early break
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------------
+// miscellaneous
+
+void Startup::printInheritanceTable() {
+    std::map<std::string, std::vector<bool> >::iterator it;
+    for(it = inheritanceTable.begin(); it != inheritanceTable.end(); it++) {
+        std::cout << it->first;
+        for(unsigned int i = 0; i < numOfTypes; i++) {
+            std::cout << " " << it->second[i];
+        }
+        std::cout << std::endl;
+    }
+}
+
+void Startup::printInterfaceMethodTable() {
+    std::map<std::string, std::vector<ClassMethodTable*> >::iterator it;
+    for(it = interfaceMethodTable.begin(); it != interfaceMethodTable.end(); it++) {
+        std::cout << it->first;
+        for(unsigned int i = 0; i < numOfInterfaceMethods; i++) {
+            std::cout << " ";
+            if(it->second[i] == NULL) {
+                std::cout << "NULL";
+            } else {
+                std::cout << it->second[i]->getClassMethod()->getMethodHeader()->methodSignatureAsString();
+            }
+        }
+        std::cout << std::endl;
     }
 }

--- a/src/disambiguate/ambiguousLinker.cpp
+++ b/src/disambiguate/ambiguousLinker.cpp
@@ -1571,6 +1571,12 @@ void AmbiguousLinker::setMethodForMethodInvokeFromCompilation(MethodInvoke* invo
         if(method != NULL) {
             invoke->setReferredClassMethod(method);
         } else {
+            /* InterfaceMethodTable* method = someType->getInterfaceMethodFromClass(methodSignature);
+            if(method != NULL) {
+                invoke->setReferredInterfaceMethod(method);
+                return;
+            }*/
+            // anything else
             ss << "Class method with signature '" << methodSignature << "' could not be found in class '"
                << someType->getCanonicalName() << "'.";
             Error(E_DISAMBIGUATION, tok, ss.str());

--- a/src/hierarchy-checking/hierarchyChecking.cpp
+++ b/src/hierarchy-checking/hierarchyChecking.cpp
@@ -780,7 +780,15 @@ void HierarchyChecking::establishInheritance(CompilationTable* compilation) {
             // recursively establish the superclass's constructors and methods first
             establishInheritance(aClass->getSuper()->getSuperClassTable());
         }
-        // make sure this class inherits all the methods and fields of its superclass, if any
+
+        Interfaces* implInterface = aClass->getImplementInterfaces()->getListOfInterfaces();
+        while(implInterface != NULL) {
+            // establish inheritance for implemented interface first
+            establishInheritance(implInterface->getImplOrExtInterfaceTable());
+            implInterface = implInterface->getNextInterface();
+        }
+        // make sure this class inherits all the methods and fields of its superclass
+        // and superinterface, if any
         compilation->inheritClassFieldsAndMethods();
     } else if(!compilation->isClassSymbolTable() && !compilation->isInheritanceEstablished()) {
         // an interface that has not had it's inheritance established

--- a/src/hierarchy-checking/hierarchyChecking.cpp
+++ b/src/hierarchy-checking/hierarchyChecking.cpp
@@ -532,7 +532,7 @@ void HierarchyChecking::checkMethodModifiers(CompilationTable* compilation){
                                     std::stringstream ss;
                                     if(mh->isVoidReturnType())
                                     {
-                                        ss << "Method '" << signature << "with return type void' in class '" << processing->getClassOrInterfaceName()
+                                        ss << "Method '" << signature << "' with return type 'void' in class '" << processing->getClassOrInterfaceName()
                                             << "' cannot be overriden by a method with return type " << methods[signature] << ".";
                                     }
                                     else
@@ -573,7 +573,7 @@ void HierarchyChecking::checkMethodModifiers(CompilationTable* compilation){
 
                             if(mh->isVoidReturnType())
                             {
-                                methods[signature] = "";
+                                methods[signature] = "void";
                             }
                             else
                             {
@@ -645,7 +645,7 @@ void HierarchyChecking::checkMethodModifiers(CompilationTable* compilation){
                         }
                         if(im->isVoidReturnType())
                         {
-                            methods[signature] = "";
+                            methods[signature] = "void";
                         }
                         else
                         {

--- a/src/hierarchy-checking/hierarchyChecking.cpp
+++ b/src/hierarchy-checking/hierarchyChecking.cpp
@@ -527,7 +527,7 @@ void HierarchyChecking::checkMethodModifiers(CompilationTable* compilation){
                             std::string signature = mh->methodSignatureAsString();
                             if(methods.count(signature) == 1)
                             {
-                                if((mh->isVoidReturnType() && methods[signature] != "") || (!mh->isVoidReturnType() && methods[signature] != mh->getReturnType()->getTypeAsString()))
+                                if((mh->isVoidReturnType() && methods[signature] != "void") || (!mh->isVoidReturnType() && methods[signature] != mh->getReturnType()->getTypeAsString()))
                                 {
                                     std::stringstream ss;
                                     if(mh->isVoidReturnType())
@@ -537,7 +537,7 @@ void HierarchyChecking::checkMethodModifiers(CompilationTable* compilation){
                                     }
                                     else
                                     {
-                                        ss << "Method '" << signature << "with return type " << mh->getReturnType()->getTypeAsString() << "' in class '" << processing->getClassOrInterfaceName()
+                                        ss << "Method '" << signature << " with return type " << mh->getReturnType()->getTypeAsString() << "' in class '" << processing->getClassOrInterfaceName()
                                             << "' cannot be overriden by a method with return type " << methods[signature] << ".";
                                     }
                                     Error(E_HIERARCHY, token, ss.str());
@@ -619,17 +619,17 @@ void HierarchyChecking::checkMethodModifiers(CompilationTable* compilation){
                         std::string signature = im->methodSignatureAsString();
                         if(methods.count(signature) == 1)
                         {
-                            if((im->isVoidReturnType() && methods[signature] != "") || (!im->isVoidReturnType() && methods[signature] != im->getReturnType()->getTypeAsString()))
+                            if((im->isVoidReturnType() && methods[signature] != "void") || (!im->isVoidReturnType() && methods[signature] != im->getReturnType()->getTypeAsString()))
                             {
                                 std::stringstream ss;
                                 if(im->isVoidReturnType())
                                 {
-                                    ss << "Method '" << signature << "with return type  void ' in interface '" << processing->getClassOrInterfaceName()
+                                    ss << "Method '" << signature << "' with return type  void ' in interface '" << processing->getClassOrInterfaceName()
                                         << "' cannot be overriden by a method with return type " << methods[signature] << ".";
                                 }
                                 else
                                 {
-                                    ss << "Method '" << signature << "with return type " << im->getReturnType()->getTypeAsString() << "' in interface '" << processing->getClassOrInterfaceName()
+                                    ss << "Method '" << signature << "' with return type " << im->getReturnType()->getTypeAsString() << "' in interface '" << processing->getClassOrInterfaceName()
                                         << "' cannot be overriden by a method with return type " << methods[signature] << ".";
                                 }
                                 Error(E_HIERARCHY, token, ss.str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,11 +121,12 @@ int main(int argc, char *argv[])
         PackagesManager pkgManager(packagesCompilations);
         AmbiguousLinker(pkgManager, packagesCompilations).performLinking();
         CHECK_ERROR();
+
         TypeChecking(pkgManager, packagesCompilations).check();
         CHECK_ERROR();
+        
         Reachable(packagesCompilations).checkReachability();
         CHECK_ERROR();
-
 
         Startup(compilationTables).buildTables();
     } catch (std::exception &e) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "ambiguousLinker.h"
 #include "typeChecker.h"
 #include "reachable.h"
+#include "startup.h"
 
 int main(int argc, char *argv[])
 {
@@ -124,6 +125,9 @@ int main(int argc, char *argv[])
         CHECK_ERROR();
         Reachable(packagesCompilations).checkReachability();
         CHECK_ERROR();
+
+
+        Startup(compilationTables).buildTables();
     } catch (std::exception &e) {
         Error::print();
         delete newParseTrees;


### PR DESCRIPTION
This PR updates the following:
- Some code generation related things, namely interface method tables and inheritance table
- Small fixes on previous parts
- Classes now inherit interface methods from implemented interfaces, previously they do not. Consequently then classes have a mapping of method signature to InterfaceMethodTable\* now and the method getInterfaceMethodFromClass of CompilationTable returns an InterfaceMethodTable\* that matches with the given method signature. However this currently causes a segfault in the type checking stage because of the exclusive use of getAClassMethod to get methods from a class. Now that a class inherits interface methods, simply calling getAClassMethod doesn't work since the method linked might be an interface method and getAClassMethod returns the methods defined within the class and inherited from superclasses. The advised alternative is to call the Primary AST node methods getReferredClassMethod and getReferredInterfaceMethod after checking for isReferringToClassMethod and isReferringToInterfaceMethod. Currently a part of the AmbiguousLinker is commented out to not cause a segmentation fault. Once this issue is resolved, it will be put back on
